### PR TITLE
Complete construction api + tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,5 +2,4 @@ build:
 	go build
 
 test:
-	go test
-
+	go test -v

--- a/construction_api.go
+++ b/construction_api.go
@@ -7,11 +7,11 @@ type RosettaConstructionTool interface {
 	//   - error when deriving address from the public key
 	DeriveFromPublicKey(publicKey []byte) (string, error)
 
-	// Sign defines the function to sign an arbitrary message with the private key (secp256k1)
+	// Sign defines the function to sign an arbitrary message with the secret key (secp256k1)
 	// @return (secp256k1)
 	//   - signature [string] the signature after the message is signed with the private key
 	//   - error when signing a message
-	Sign(message []byte, privateKey []byte) ([]byte, error)
+	Sign(message []byte, sk []byte) ([]byte, error)
 
 	// Verify defines the function to verify the signature of an arbitrary message with the public key (secp256k1)
 	// @return
@@ -36,11 +36,11 @@ type RosettaConstructionTool interface {
 	//   - error while constructing the multisig SwapAuthorizedParty call
 	ConstructSwapAuthorizedParty(request *MultisigPaymentRequest) (string, error)
 
-	// SignTx signs an unsignedTx using the private key (secp256k1) and return a signedTx that can be submitted to the node
+	// SignTx signs an unsignedTx using the secret key (secp256k1) and return a signedTx that can be submitted to the node
 	// @return
-	//   - signedTx [byte] the signed transaction
+	//   - signedTx [string] the signed transaction
 	//   - error when signing a transaction
-	SignTx(unsignedTransaction string, privateKey []byte) ([]byte, error)
+	SignTx(unsignedTransaction string, sk []byte) (string, error)
 
 	// ParseTx defines the function to parse a transaction
 	// @return
@@ -52,7 +52,7 @@ type RosettaConstructionTool interface {
 	// @return
 	//   - txHash [string] transaction hash
 	//   - error when calculating the tx hash
-	Hash(signedTx []byte) (string, error)
+	Hash(signedTx string) (string, error)
 }
 
 // Modify this as needed to add in new fields

--- a/construction_api.go
+++ b/construction_api.go
@@ -20,9 +20,9 @@ type RosettaConstructionTool interface {
 
 	// ConstructPayment creates transaction for a normal send
 	// @return
-	//   - unsignedTx [byte]
+	//   - unsignedTx [string]
 	//   - error while constructing the normal send transaction
-	ConstructPayment(request *PaymentRequest) ([]byte, error)
+	ConstructPayment(request *PaymentRequest) (string, error)
 
 	// ConstructMultisigPayment creates transaction for a multisig send
 	// @return
@@ -73,20 +73,33 @@ type PaymentRequest struct {
 	Metadata TxMetadata `json:"metadata"`
 }
 
+// MultisigPaymentParams defines params for MultisigPaymentRequest
+type MultisigPaymentParams struct {
+	To       string `json:"to"`
+	Quantity uint64 `json:"quantity"`
+}
 
 // MultisigPaymentRequest defines the input to ConstructMultisigPayment
 type MultisigPaymentRequest struct {
+	Multisig   string `json:"multisig"`
+	From       string `json:"from"`
+	Quantity   uint64 `json:"quantity"`
+	Metadata   TxMetadata `json:"metadata"`
+	Params     MultisigPaymentParams `json:"params"`
+}
+
+// SwapAuthorizedPartyParams defines the params
+type SwapAuthorizedPartyParams struct {
 	From     string `json:"from"`
 	To       string `json:"to"`
-	Quantity uint64 `json:"quantity"`
-	Metadata TxMetadata `json:"metadata"`
 }
 
 // SwapAuthorizedPartyRequest defines the input to ConstructSwapAuthorizedParty
 type SwapAuthorizedPartyRequest struct {
+	Multisig string `json: "multisig"`
 	From     string `json:"from"`
-	To       string `json:"to"`
 	Metadata TxMetadata `json:"metadata"`
+	Params   SwapAuthorizedPartyParams `json; "params"`
 }
 
 // ParseTxRequest defines the input to ParseTx

--- a/construction_api.go
+++ b/construction_api.go
@@ -20,9 +20,9 @@ type RosettaConstructionTool interface {
 
 	// ConstructPayment creates transaction for a normal send
 	// @return
-	//   - unsignedTx [string]
+	//   - unsignedTx [byte]
 	//   - error while constructing the normal send transaction
-	ConstructPayment(request *PaymentRequest) (string, error)
+	ConstructPayment(request *PaymentRequest) ([]byte, error)
 
 	// ConstructMultisigPayment creates transaction for a multisig send
 	// @return
@@ -38,28 +38,28 @@ type RosettaConstructionTool interface {
 
 	// SignTx signs an unsignedTx using the private key (secp256k1) and return a signedTx that can be submitted to the node
 	// @return
-	//   - signedTx [string] the signed transaction
+	//   - signedTx [byte] the signed transaction
 	//   - error when signing a transaction
-	SignTx(unsignedTransaction string, privateKey []byte) (string, error)
+	SignTx(unsignedTransaction string, privateKey []byte) ([]byte, error)
 
 	// ParseTx defines the function to parse a transaction
 	// @return
-	//   - message [string] the parsed transaction (message), this will either be a Message or a SignedMessage
+	//   - message [bytes] the parsed transaction (message), this will either be a Message or a SignedMessage
 	//   - error when parsing a transaction
-	ParseTx(request *ParseTxRequest) (interface{}, error)
+	ParseTx(b []byte) (interface{}, error)
 
 	// Hash defines the function to calculate a tx hash
 	// @return
 	//   - txHash [string] transaction hash
 	//   - error when calculating the tx hash
-	Hash(signedTx string) (string, error)
+	Hash(signedTx []byte) (string, error)
 }
 
 // Modify this as needed to add in new fields
 type TxMetadata struct {
 	Nonce               uint64 `json:"nonce"`
 	GasPrice            string `json:"gasPrice,omitempty"`
-	GasLimit            string `json:"gasLimit,omitempty"`
+	GasLimit            int64 `json:"gasLimit,omitempty"`
 	ChainId             string `json:"chainId"`
 	Method              uint64 `json:"method,omitempty"`
 	Params              []byte `json:"params,omitempty"`

--- a/construction_impl.go
+++ b/construction_impl.go
@@ -15,9 +15,17 @@
 ********************************************************************************/
 package rosetta_filecoin_lib
 
-import "github.com/filecoin-project/go-address"
-import "github.com/filecoin-project/lotus/lib/sigs"
-import "github.com/filecoin-project/specs-actors/actors/crypto"
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/lotus/lib/sigs"
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/specs-actors/actors/crypto"
+	cbg "github.com/whyrusleeping/cbor-gen"
+	"encoding/json"
+)
 
 type RosettaConstructionFilecoin struct {
 	Mainnet bool
@@ -29,6 +37,7 @@ func (r RosettaConstructionFilecoin) DeriveFromPublicKey(publicKey []byte) (stri
 		return "", err
 	}
 	// FIXME: go=address does not allow setting a network
+	// https://github.com/filecoin-project/go-address/issues/6
 
 	return addr.String(), nil
 }
@@ -57,8 +66,36 @@ func (r RosettaConstructionFilecoin) Verify(message []byte, publicKey []byte, si
 	return sigs.Verify(&sig, addr, message)
 }
 
-func (r RosettaConstructionFilecoin) ConstructPayment(request *PaymentRequest) (string, error) {
-	panic("implement me")
+func (r RosettaConstructionFilecoin) ConstructPayment(request *PaymentRequest) ([]byte, error) {
+	to, err := address.NewFromString(request.To)
+	if err != nil {
+		return nil, err
+	}
+
+	from, err := address.NewFromString(request.From)
+	if err != nil {
+		return nil, err
+	}
+
+	value := types.NewInt(request.Quantity)
+
+	gasprice, err := types.BigFromString(request.Metadata.GasPrice)
+	if err != nil {
+		return nil, err
+	}
+
+	msg := &types.Message{types.MessageVersion,
+		to,
+		from,
+		request.Metadata.Nonce,
+		value,
+		gasprice,
+		request.Metadata.GasLimit,
+		0,
+		make([]byte,0),
+	}
+
+	return json.Marshal(msg)
 }
 
 func (r RosettaConstructionFilecoin) ConstructMultisigPayment(request *MultisigPaymentRequest) (string, error) {
@@ -69,16 +106,72 @@ func (r RosettaConstructionFilecoin) ConstructSwapAuthorizedParty(request *Multi
 	panic("implement me")
 }
 
-func (r RosettaConstructionFilecoin) SignTx(unsignedTransaction string, privateKey []byte) (string, error) {
-//	m := types.Message
+func (r RosettaConstructionFilecoin) SignTx(unsignedTransaction string, privateKey []byte) ([]byte, error) {
+	rawIn := json.RawMessage(unsignedTransaction)
 
-	panic("implement me")
+	bytes, err := rawIn.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	var msg types.Message
+	err = json.Unmarshal(bytes, &msg)
+	if err != nil {
+		return nil, err
+	}
+
+	ser, err := msg.Serialize()
+	if err != nil {
+		return nil, err
+	}
+
+	return r.Sign(ser, privateKey)
 }
 
-func (r RosettaConstructionFilecoin) ParseTx(request *ParseTxRequest) (interface{}, error) {
-	panic("implement me")
+func (r RosettaConstructionFilecoin) ParseTx(b []byte) (interface{}, error) {
+	br := cbg.GetPeeker(bytes.NewReader(b))
+	scratch := make([]byte, 8)
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if maj != cbg.MajArray {
+		return nil, fmt.Errorf("cbor input should be of type array")
+	}
+
+	switch extra {
+		case 9:
+			// Unsigned message
+			msg, err := types.DecodeMessage(b)
+			if err != nil {
+				return nil, err
+			}
+			return *msg, nil
+		case 2:
+			// Signed message
+			msg, err := types.DecodeSignedMessage(b)
+			if err != nil {
+				return nil, err
+			}
+			return *msg, nil
+		default:
+			return nil, fmt.Errorf("cbor input had wrong number of fields")
+	}
+
 }
 
-func (r RosettaConstructionFilecoin) Hash(signedTx string) (string, error) {
-	panic("implement me")
+func (r RosettaConstructionFilecoin) Hash(signedMessage []byte) (string, error) {
+	msg, err := r.ParseTx(signedMessage)
+	if err != nil {
+		return "", err
+	}
+
+	switch msg := msg.(type) {
+		case types.SignedMessage:
+				return msg.Cid().String(), nil
+		default:
+			return "", fmt.Errorf("Message need to be a SignedMessage")
+	}
 }

--- a/construction_impl_test.go
+++ b/construction_impl_test.go
@@ -14,3 +14,110 @@
 *  limitations under the License.
 ********************************************************************************/
 package rosetta_filecoin_lib
+
+import (
+  "testing"
+  "encoding/hex"
+  "github.com/filecoin-project/lotus/chain/types"
+  "github.com/filecoin-project/specs-actors/actors/abi"
+)
+
+func TestDeriveFromPublicKey(t *testing.T) {
+  t.Errorf("No test")
+}
+
+func TestSign(t *testing.T) {
+  t.Errorf("No test")
+}
+
+func TestVerify(t *testing.T) {
+  t.Errorf("No test")
+}
+
+func TestConstructPayment(t *testing.T) {
+  t.Errorf("No test")
+}
+
+func TestConstructMultisigPayment(t *testing.T) {
+  t.Errorf("No test")
+}
+
+func TestConstructSwapAuthorizedParty(t *testing.T) {
+  t.Errorf("No test")
+}
+
+func TestSignTx(t *testing.T) {
+  t.Errorf("No test")
+}
+
+func TestParseTx(t *testing.T) {
+  serialized_tx := "89005501fd1d0f4dfcd7e99afcb99a8326b7dc459d32c6285501b882619d46558f3d9e316d11b48dcf211327025a0144000186a0430009c41961a80040"
+  r := &RosettaConstructionFilecoin{true}
+  b, err := hex.DecodeString(serialized_tx)
+
+  if err != nil {
+    t.Errorf("Invalid test case")
+  }
+
+  msg, err := r.ParseTx(b)
+
+  if err != nil {
+    t.Fail()
+  }
+
+  switch msg := msg.(type) {
+    case types.Message:
+      if msg.To.String() != "t17uoq6tp427uzv7fztkbsnn64iwotfrristwpryy" {
+        t.Errorf("Invalid To address returned")
+      }
+      if msg.From.String() != "t1xcbgdhkgkwht3hrrnui3jdopeejsoas2rujnkdi" {
+        t.Errorf("Invalid From address returned")
+      }
+      if msg.Nonce != uint64(1) {
+        t.Errorf("Invalid Nonce returned")
+      }
+      if types.BigCmp(msg.Value, types.NewInt(100000)) > 0 {
+        t.Errorf("Invalid Value returned")
+      }
+      if types.BigCmp(msg.GasPrice,types.NewInt(2500)) > 0 {
+        t.Errorf("Invalid GasPrice returned")
+      }
+      if msg.GasLimit != int64(25000) {
+        t.Errorf("Invalid GasLimit returned")
+      }
+      if msg.Method != abi.MethodNum(0) {
+        t.Errorf("Invalid Method returned")
+      }
+      // FIXME
+      /*if msg.Params != make([]byte, 0) {
+        t.Errorf("Invalid Params returned")
+      }*/
+    case types.SignedMessage:
+      t.Log(msg.Message.To)
+    default:
+      t.Errorf("This should never happened")
+
+  }
+}
+
+func TestHash(t *testing.T) {
+  serialized_signed_tx := "8289005501fd1d0f4dfcd7e99afcb99a8326b7dc459d32c62855011eaf1c8a4bbfeeb0870b1745b1f57503470b71160144000186a0430009c41909c4004058420106398485060ca2a4deb97027f518f45569360c3873a4303926fa6909a7299d4c55883463120836358ff3396882ee0dc2cf15961bd495cdfb3de1ee2e8bd3768e01"
+  r := &RosettaConstructionFilecoin{true}
+  b, err := hex.DecodeString(serialized_signed_tx)
+
+  if err != nil {
+    t.Errorf("Invalid test case")
+  }
+
+  cid, err := r.Hash(b)
+
+  if err != nil {
+    t.Errorf("Something went Wrong")
+  }
+
+  t.Log(cid)
+
+  if cid != "bafy2bzacedt2zox7kxwtuhorhtwsaxkjs5hz2t543uf5fjvwlcu5uqzgfzxwy" {
+      t.Fail()
+  }
+}

--- a/construction_impl_test.go
+++ b/construction_impl_test.go
@@ -20,6 +20,7 @@ import (
   "encoding/hex"
   "encoding/base64"
   "encoding/json"
+  "reflect"
   "github.com/filecoin-project/lotus/chain/types"
   "github.com/filecoin-project/specs-actors/actors/abi"
 )
@@ -132,15 +133,157 @@ func TestVerify(t *testing.T) {
 }
 
 func TestConstructPayment(t *testing.T) {
-  t.Skipf("No test")
+  expected := `{
+    "Version": 0,
+    "To": "t17uoq6tp427uzv7fztkbsnn64iwotfrristwpryy",
+    "From": "t1d2xrzcslx7xlbbylc5c3d5lvandqw4iwl6epxba",
+    "Nonce": 1,
+    "Value": "100000",
+    "GasPrice": "2500",
+    "GasLimit": 25000,
+    "Method": 0,
+    "Params": ""
+  }`
+  r := &RosettaConstructionFilecoin{false}
+  mtx := TxMetadata{
+    Nonce: 1,
+    GasPrice: "2500",
+    GasLimit: 25000,
+  }
+  pr := &PaymentRequest{
+    From: "t1d2xrzcslx7xlbbylc5c3d5lvandqw4iwl6epxba",
+    To: "t17uoq6tp427uzv7fztkbsnn64iwotfrristwpryy",
+    Quantity: 100000,
+    Metadata: mtx,
+  }
+
+  tx, err := r.ConstructPayment(pr)
+  if err != nil {
+    t.Errorf("FIX ME")
+  }
+
+  var expectedTx types.Message
+  var resultTx types.Message
+
+  err = json.Unmarshal([]byte(expected), &expectedTx)
+  if err != nil {
+    t.Errorf("FIX ME")
+  }
+
+  err = json.Unmarshal([]byte(tx), &resultTx)
+  if err != nil {
+    t.Errorf("FIX ME")
+  }
+
+  if !reflect.DeepEqual(expectedTx, resultTx) {
+    t.Fail()
+  }
+
 }
 
 func TestConstructMultisigPayment(t *testing.T) {
-  t.Skipf("No test")
+  expected := `{
+    "Version": 0,
+    "To": "t01002",
+    "From": "t1d2xrzcslx7xlbbylc5c3d5lvandqw4iwl6epxba",
+    "Nonce": 1,
+    "Value": "0",
+    "GasPrice": "2500",
+    "GasLimit": 25000,
+    "Method": 2,
+    "Params": "hFUB/R0PTfzX6Zr8uZqDJrfcRZ0yxihDAAPoAEA="
+  }`
+  r := &RosettaConstructionFilecoin{false}
+  mtx := TxMetadata{
+    Nonce: 1,
+    GasPrice: "2500",
+    GasLimit: 25000,
+  }
+  params := MultisigPaymentParams{
+    To: "t17uoq6tp427uzv7fztkbsnn64iwotfrristwpryy",
+    Quantity: 1000,
+  }
+  request := &MultisigPaymentRequest{
+    Multisig: "t01002",
+    From: "t1d2xrzcslx7xlbbylc5c3d5lvandqw4iwl6epxba",
+    Metadata: mtx,
+    Params: params,
+  }
+
+  result, err := r.ConstructMultisigPayment(request)
+  if err != nil {
+    t.Errorf("FIX ME")
+  }
+
+  var expectedMessage types.Message
+  var resultMessage types.Message
+
+  err = json.Unmarshal([]byte(expected), &expectedMessage)
+  if err != nil {
+    t.Errorf("FIX ME")
+  }
+
+  err = json.Unmarshal([]byte(result), &resultMessage)
+  if err != nil {
+    t.Errorf("FIX ME")
+  }
+
+  if !reflect.DeepEqual(expectedMessage, resultMessage) {
+    t.Fail()
+  }
 }
 
 func TestConstructSwapAuthorizedParty(t *testing.T) {
-  t.Skipf("No test")
+  expected := `{
+    "Version": 0,
+    "To": "t01002",
+    "From": "t1d2xrzcslx7xlbbylc5c3d5lvandqw4iwl6epxba",
+    "Nonce": 1,
+    "Value": "0",
+    "GasPrice": "2500",
+    "GasLimit": 25000,
+    "Method": 7,
+    "Params": "glUB/R0PTfzX6Zr8uZqDJrfcRZ0yxihYMQOuzzY13jMOTmpShDszOIxbNhcAhlxVLRYZmVI87UlsVOZXuGJil7OSixyQSOsTXug="
+  }`
+  r := &RosettaConstructionFilecoin{false}
+  mtx := TxMetadata{
+    Nonce: 1,
+    GasPrice: "2500",
+    GasLimit: 25000,
+  }
+  params := SwapAuthorizedPartyParams{
+    From: "t17uoq6tp427uzv7fztkbsnn64iwotfrristwpryy",
+    To: "t3v3htmno6gmhe42ssqq5tgoemlm3boaeglrks2fqztfjdz3kjnrkomv5ymjrjpm4srmojashlcnporcluiyaa",
+  }
+  request := &SwapAuthorizedPartyRequest{
+    Multisig: "t01002",
+    From: "t1d2xrzcslx7xlbbylc5c3d5lvandqw4iwl6epxba",
+    Metadata: mtx,
+    Params: params,
+  }
+
+  result, err := r.ConstructSwapAuthorizedParty(request)
+  if err != nil {
+    t.Errorf("FIX ME")
+  }
+
+  var expectedMessage types.Message
+  var resultMessage types.Message
+
+  err = json.Unmarshal([]byte(expected), &expectedMessage)
+  if err != nil {
+    t.Errorf("FIX ME")
+  }
+
+  err = json.Unmarshal([]byte(result), &resultMessage)
+  if err != nil {
+    t.Errorf("FIX ME")
+  }
+
+  if !reflect.DeepEqual(expectedMessage, resultMessage) {
+    t.Fail()
+  }
+
 }
 
 func TestSignTx(t *testing.T) {

--- a/construction_impl_test.go
+++ b/construction_impl_test.go
@@ -18,42 +18,182 @@ package rosetta_filecoin_lib
 import (
   "testing"
   "encoding/hex"
+  "encoding/base64"
+  "encoding/json"
   "github.com/filecoin-project/lotus/chain/types"
   "github.com/filecoin-project/specs-actors/actors/abi"
 )
 
 func TestDeriveFromPublicKey(t *testing.T) {
-  t.Errorf("No test")
+  pk, err := hex.DecodeString("04fc016f3d88dc7070cdd95b5754d32fd5290f850b7c2208fca0f715d35861de1841d9a342a487692a63810a6c906b443a18aa804d9d508d69facc5b06789a01b4")
+  if err != nil {
+    t.Errorf("Invalid test case")
+  }
+
+  r := &RosettaConstructionFilecoin{false}
+
+  address, err := r.DeriveFromPublicKey(pk)
+  if err != nil {
+    t.Errorf("FIX ME")
+  }
+
+  if address != "t1rovwtiuo5ncslpmpjftzu5akswbgsgighjazxoi" {
+    t.Fail()
+  }
+
 }
 
 func TestSign(t *testing.T) {
-  t.Errorf("No test")
+  unsignedTx := `{
+    "To": "t17uoq6tp427uzv7fztkbsnn64iwotfrristwpryy",
+    "From": "t1d2xrzcslx7xlbbylc5c3d5lvandqw4iwl6epxba",
+    "Nonce": 1,
+    "Value": "100000",
+    "GasPrice": "2500",
+    "GasLimit": 25000,
+    "Method": 0,
+    "Params": ""
+  }`
+  sk, err := hex.DecodeString("f15716d3b003b304b8055d9cc62e6b9c869d56cc930c3858d4d7c31f5f53f14a")
+  if err != nil {
+    t.Errorf("FIX ME")
+  }
+  r := &RosettaConstructionFilecoin{false}
+
+  rawIn := json.RawMessage(unsignedTx)
+
+  bytes, err := rawIn.MarshalJSON()
+  if err != nil {
+    t.Errorf("FIX ME")
+  }
+
+  var msg types.Message
+  err = json.Unmarshal(bytes, &msg)
+  if err != nil {
+    t.Errorf("FIX ME")
+  }
+
+  digest := msg.Cid().Bytes()
+
+  sig, err := r.Sign(digest, sk)
+  if err != nil {
+    t.Errorf("FIX ME")
+  }
+
+  if base64.StdEncoding.EncodeToString(sig) != "BjmEhQYMoqTeuXAn9Rj0VWk2DDhzpDA5JvppCacpnUxViDRjEgg2NY/zOWiC7g3CzxWWG9SVzfs94e4ui9N2jgE=" {
+    t.Fail()
+  }
+
 }
 
 func TestVerify(t *testing.T) {
-  t.Errorf("No test")
+  unsignedTx := `{
+    "To": "t17uoq6tp427uzv7fztkbsnn64iwotfrristwpryy",
+    "From": "t1d2xrzcslx7xlbbylc5c3d5lvandqw4iwl6epxba",
+    "Nonce": 1,
+    "Value": "100000",
+    "GasPrice": "2500",
+    "GasLimit": 25000,
+    "Method": 0,
+    "Params": ""
+  }`
+
+  pk, err := hex.DecodeString("0435e752dc6b4113f78edcf2cf7b8082e442021de5f00818f555397a6f181af795ace98f0f7d065793eaffa1b06bf52e572c97030c53a2396dfab40ba0e976b108")
+  if err != nil {
+    t.Errorf("FIX ME")
+  }
+  sig, err := base64.StdEncoding.DecodeString("BjmEhQYMoqTeuXAn9Rj0VWk2DDhzpDA5JvppCacpnUxViDRjEgg2NY/zOWiC7g3CzxWWG9SVzfs94e4ui9N2jgE=")
+  if err != nil {
+    t.Errorf("FIX ME")
+  }
+  r := &RosettaConstructionFilecoin{false}
+
+  rawIn := json.RawMessage(unsignedTx)
+
+  bytes, err := rawIn.MarshalJSON()
+  if err != nil {
+    t.Errorf("FIX ME")
+  }
+
+  var msg types.Message
+  err = json.Unmarshal(bytes, &msg)
+  if err != nil {
+    t.Errorf("FIX ME")
+  }
+
+  digest := msg.Cid().Bytes()
+
+  err = r.Verify(digest, pk, sig)
+
+  if err != nil {
+    t.Fail()
+  }
+
 }
 
 func TestConstructPayment(t *testing.T) {
-  t.Errorf("No test")
+  t.Skipf("No test")
 }
 
 func TestConstructMultisigPayment(t *testing.T) {
-  t.Errorf("No test")
+  t.Skipf("No test")
 }
 
 func TestConstructSwapAuthorizedParty(t *testing.T) {
-  t.Errorf("No test")
+  t.Skipf("No test")
 }
 
 func TestSignTx(t *testing.T) {
-  t.Errorf("No test")
+  unsignedTx := `{
+    "To": "t17uoq6tp427uzv7fztkbsnn64iwotfrristwpryy",
+    "From": "t1d2xrzcslx7xlbbylc5c3d5lvandqw4iwl6epxba",
+    "Nonce": 1,
+    "Value": "100000",
+    "GasPrice": "2500",
+    "GasLimit": 25000,
+    "Method": 0,
+    "Params": ""
+  }`
+  sk := "f15716d3b003b304b8055d9cc62e6b9c869d56cc930c3858d4d7c31f5f53f14a"
+  r := &RosettaConstructionFilecoin{false}
+
+  skBytes, err := hex.DecodeString(sk)
+
+  if err != nil {
+    t.Errorf("Invalid test case")
+  }
+
+  signedTx, err := r.SignTx(unsignedTx, skBytes)
+  if err != nil {
+    t.Error(err)
+  }
+
+  t.Log(signedTx)
+
+  rawIn := json.RawMessage(signedTx)
+
+  bytes, err := rawIn.MarshalJSON()
+  if err != nil {
+    t.Errorf("Not a json string")
+  }
+
+  var msg types.SignedMessage
+  err = json.Unmarshal(bytes, &msg)
+  if err != nil {
+    t.Errorf("Not a SignedMessage")
+  }
+
+  dataSignature := base64.StdEncoding.EncodeToString(msg.Signature.Data)
+  if dataSignature != "BjmEhQYMoqTeuXAn9Rj0VWk2DDhzpDA5JvppCacpnUxViDRjEgg2NY/zOWiC7g3CzxWWG9SVzfs94e4ui9N2jgE=" {
+    t.Fail()
+  }
+
 }
 
 func TestParseTx(t *testing.T) {
-  serialized_tx := "89005501fd1d0f4dfcd7e99afcb99a8326b7dc459d32c6285501b882619d46558f3d9e316d11b48dcf211327025a0144000186a0430009c41961a80040"
-  r := &RosettaConstructionFilecoin{true}
-  b, err := hex.DecodeString(serialized_tx)
+  serializedTx := "89005501fd1d0f4dfcd7e99afcb99a8326b7dc459d32c6285501b882619d46558f3d9e316d11b48dcf211327025a0144000186a0430009c41961a80040"
+  r := &RosettaConstructionFilecoin{false}
+  b, err := hex.DecodeString(serializedTx)
 
   if err != nil {
     t.Errorf("Invalid test case")
@@ -101,15 +241,25 @@ func TestParseTx(t *testing.T) {
 }
 
 func TestHash(t *testing.T) {
-  serialized_signed_tx := "8289005501fd1d0f4dfcd7e99afcb99a8326b7dc459d32c62855011eaf1c8a4bbfeeb0870b1745b1f57503470b71160144000186a0430009c41909c4004058420106398485060ca2a4deb97027f518f45569360c3873a4303926fa6909a7299d4c55883463120836358ff3396882ee0dc2cf15961bd495cdfb3de1ee2e8bd3768e01"
-  r := &RosettaConstructionFilecoin{true}
-  b, err := hex.DecodeString(serialized_signed_tx)
+  signedTx := `{
+    "Message": {
+      "To": "t17uoq6tp427uzv7fztkbsnn64iwotfrristwpryy",
+      "From": "t1d2xrzcslx7xlbbylc5c3d5lvandqw4iwl6epxba",
+      "Nonce": 1,
+      "Value": "100000",
+      "GasPrice": "2500",
+      "GasLimit": 25000,
+      "Method": 0,
+      "Params": ""
+    },
+    "Signature": {
+      "Types": 1,
+      "Data": "BjmEhQYMoqTeuXAn9Rj0VWk2DDhzpDA5JvppCacpnUxViDRjEgg2NY/zOWiC7g3CzxWWG9SVzfs94e4ui9N2jgE="
+    }
+  }`
+  r := &RosettaConstructionFilecoin{false}
 
-  if err != nil {
-    t.Errorf("Invalid test case")
-  }
-
-  cid, err := r.Hash(b)
+  cid, err := r.Hash(signedTx)
 
   if err != nil {
     t.Errorf("Something went Wrong")
@@ -117,7 +267,7 @@ func TestHash(t *testing.T) {
 
   t.Log(cid)
 
-  if cid != "bafy2bzacedt2zox7kxwtuhorhtwsaxkjs5hz2t543uf5fjvwlcu5uqzgfzxwy" {
+  if cid != "bafy2bzacedbhs4ewvpqjg2vdarfo4ux7nbwzvwrh36jrwsnpf6474qaicd6by" {
       t.Fail()
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/filecoin-project/go-address v0.0.2-0.20200504173055-8b6f2fb2b3ef
 	github.com/filecoin-project/lotus v0.4.1
 	github.com/filecoin-project/specs-actors v0.6.2-0.20200702170846-2cd72643a5cf
+	github.com/whyrusleeping/cbor-gen v0.0.0-20200504204219-64967432584d
 )

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,9 @@ go 1.14
 
 require (
 	github.com/filecoin-project/go-address v0.0.2-0.20200504173055-8b6f2fb2b3ef
+	github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03
 	github.com/filecoin-project/lotus v0.4.1
 	github.com/filecoin-project/specs-actors v0.6.2-0.20200702170846-2cd72643a5cf
+	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1
 	github.com/whyrusleeping/cbor-gen v0.0.0-20200504204219-64967432584d
 )

--- a/go.sum
+++ b/go.sum
@@ -185,6 +185,7 @@ github.com/filecoin-project/filecoin-ffi v0.0.0-20200326153646-e899cc1dd072/go.m
 github.com/filecoin-project/filecoin-ffi v0.26.1-0.20200508175440-05b30afeb00d h1:smoOJ2TGTYFsmBaH01WIx4crs8axosy1V9Pi+/bdk5Y=
 github.com/filecoin-project/filecoin-ffi v0.26.1-0.20200508175440-05b30afeb00d/go.mod h1:vlQ7sDkbrtM70QMJFDvEyTDywY5SvIjadRCUB+76l90=
 github.com/filecoin-project/go-address v0.0.0-20200107215422-da8eea2842b5/go.mod h1:SAOwJoakQ8EPjwNIsiakIQKsoKdkcbx8U3IapgCg9R0=
+github.com/filecoin-project/go-address v0.0.1 h1:P8MudT6kL/c4CUk+GgjULYEfVnJ7k1E+lE+sM14g7js=
 github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be/go.mod h1:SAOwJoakQ8EPjwNIsiakIQKsoKdkcbx8U3IapgCg9R0=
 github.com/filecoin-project/go-address v0.0.2-0.20200504173055-8b6f2fb2b3ef h1:Wi5E+P1QfHP8IF27eUiTx5vYfqQZwfPxzq3oFEq8w8U=
 github.com/filecoin-project/go-address v0.0.2-0.20200504173055-8b6f2fb2b3ef/go.mod h1:SrA+pWVoUivqKOfC+ckVYbx41hWz++HxJcrlmHNnebU=


### PR DESCRIPTION
Completed

- [x] DeriveFromPublicKey (Only testnet)
- [x] Sign
- [x] Verify
- [x] ConstructPayment ( closes #1 )
- [x] ConstructMultisigPayment
- [x] ConstructSwapAuthorizedParty
- [x] SignTx ( closes #2 )
- [x] ParseTx (return only testnet address) ( closes #3 )
- [x] Hash

Note : I have modified some of the return  types. I am not if I am supposed to... I have changes for `[]byte` instead of `string`.

I have created an issue for the address problem : https://github.com/filecoin-project/go-address/issues/6
There is for now no way to set network for an address.