### PR TITLE
Verify signature when calling `Hash`

### DIFF
--- a/construction_impl.go
+++ b/construction_impl.go
@@ -562,6 +562,21 @@ func (r RosettaConstructionFilecoin) Hash(signedMessage string) (string, error) 
 	var msg types.SignedMessage
 	err = json.Unmarshal(txBytes, &msg)
 	if err != nil {
+		fmt.Println(err)
+		return "", err
+	}
+
+	// Verify teh signed message is valid to avoid generating wrong CID
+	// see https://github.com/Zondax/rosetta-filecoin-lib/issues/21
+	digest :=  msg.Message.Cid().Bytes()
+	if err != nil {
+		fmt.Println(err)
+		return "", err
+	}
+
+	err = verifySecp256k1(msg.Signature.Data, msg.Message.From, digest)
+	if err != nil {
+		fmt.Println(err)
 		return "", err
 	}
 

--- a/construction_impl.go
+++ b/construction_impl.go
@@ -568,7 +568,7 @@ func (r RosettaConstructionFilecoin) Hash(signedMessage string) (string, error) 
 
 	// Verify teh signed message is valid to avoid generating wrong CID
 	// see https://github.com/Zondax/rosetta-filecoin-lib/issues/21
-	digest :=  msg.Message.Cid().Bytes()
+	digest := msg.Message.Cid().Bytes()
 	if err != nil {
 		fmt.Println(err)
 		return "", err

--- a/construction_impl_test.go
+++ b/construction_impl_test.go
@@ -36,6 +36,7 @@ const (
 	EXPECTED_MULTISIG_PAYMENT = `{"Version":0,"To":"f01002","From":"f1d2xrzcslx7xlbbylc5c3d5lvandqw4iwl6epxba","Nonce":1,"Value":"0","GasLimit":25000,"GasFeeCap":"1","GasPremium":"1","Method":2,"Params":"hFUB/R0PTfzX6Zr8uZqDJrfcRZ0yxihDAAPoAEA=","CID":{"/":"bafy2bzaceaeyq6sksxeo7yoftkblpt6sd5umv34ha3qjdubk52u4rxleiq6eo"}}`
 	EXPECTED_SWAP_AUTHORIZED  = `{"Version":0,"To":"f01002","From":"f137sjdbgunloi7couiy4l5nc7pd6k2jmq32vizpy","Nonce":1,"Value":"0","GasLimit":25000,"GasFeeCap":"1","GasPremium":"1","Method":2,"Params":"hEMA6gdAB1gtglUB3+SRhNRq3I+J1EY4vrRfePytJZBVAeQ8w10L4iTPA9V+iE3/tipwhzV8","CID":{"/":"bafy2bzacebyohxxqn66r22dumjqcqyuqqdehz5jrnrwwcnycezyaakc45glp6"}}`
 	NETWORK                   = utils.NetworkDevnet
+	EXPECTED_SIGNATURE        = "nFuTI7MxEXqTQ0QmmQTmqbUsNZfHFXlNjz+susVDkAk1SrRCdJKxlVZZrM4vUtVBSYgtMIeigNfpqdKGIFhoWQA="
 )
 
 var seqMutex sync.Mutex
@@ -137,7 +138,7 @@ func TestSign(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 
-	if base64.StdEncoding.EncodeToString(sig) != "nFuTI7MxEXqTQ0QmmQTmqbUsNZfHFXlNjz+susVDkAk1SrRCdJKxlVZZrM4vUtVBSYgtMIeigNfpqdKGIFhoWQA=" {
+	if base64.StdEncoding.EncodeToString(sig) != EXPECTED_SIGNATURE {
 		t.Fail()
 	}
 
@@ -158,7 +159,7 @@ func TestVerify(t *testing.T) {
 
 	pkHex := "0435e752dc6b4113f78edcf2cf7b8082e442021de5f00818f555397a6f181af795ace98f0f7d065793eaffa1b06bf52e572c97030c53a2396dfab40ba0e976b108"
 
-	sigBase64 := "nFuTI7MxEXqTQ0QmmQTmqbUsNZfHFXlNjz+susVDkAk1SrRCdJKxlVZZrM4vUtVBSYgtMIeigNfpqdKGIFhoWQA="
+	sigBase64 := EXPECTED_SIGNATURE
 
 	err := verify(unsignedTx, pkHex, sigBase64)
 	if err != nil {
@@ -423,7 +424,7 @@ func TestSignTx(t *testing.T) {
 	}
 
 	dataSignature := base64.StdEncoding.EncodeToString(msg.Signature.Data)
-	if dataSignature != "nFuTI7MxEXqTQ0QmmQTmqbUsNZfHFXlNjz+susVDkAk1SrRCdJKxlVZZrM4vUtVBSYgtMIeigNfpqdKGIFhoWQA=" {
+	if dataSignature != EXPECTED_SIGNATURE {
 		t.Fail()
 	}
 

--- a/construction_impl_test.go
+++ b/construction_impl_test.go
@@ -114,8 +114,8 @@ func TestVerify(t *testing.T) {
     "From": "t1d2xrzcslx7xlbbylc5c3d5lvandqw4iwl6epxba",
     "Nonce": 1,
     "Value": "100000",
-		"GasFeeCap": "1",
-		"GasPremium": "1",
+	"GasFeeCap": "1",
+	"GasPremium": "1",
     "GasLimit": 25000,
     "Method": 0,
     "Params": ""
@@ -151,7 +151,51 @@ func TestVerify(t *testing.T) {
 	if err != nil {
 		t.Fail()
 	}
+}
 
+func TestVerify2(t *testing.T) {
+	unsignedTx := `{
+		"To": "t17uoq6tp427uzv7fztkbsnn64iwotfrristwpryy",
+		"From": "t1d2xrzcslx7xlbbylc5c3d5lvandqw4iwl6epxba",
+		"Nonce": 1,
+		"Value": "100000",
+		"GasFeeCap": "1",
+		"GasPremium": "1",
+		"GasLimit": 2500000,
+		"Method": 0,
+		"Params": ""
+  }`
+
+	pk, err := hex.DecodeString("0435e752dc6b4113f78edcf2cf7b8082e442021de5f00818f555397a6f181af795ace98f0f7d065793eaffa1b06bf52e572c97030c53a2396dfab40ba0e976b108")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	sig, err := base64.StdEncoding.DecodeString("0wRrFJZFIVh8m0JD+f5C55YrxD6YAWtCXWYihrPTKdMfgMhYAy86MVhs43hSLXnV+47UReRIe8qFdHRJqFlreAE=")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	r := &RosettaConstructionFilecoin{false}
+
+	rawIn := json.RawMessage(unsignedTx)
+
+	bytes, err := rawIn.MarshalJSON()
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	var msg types.Message
+	err = json.Unmarshal(bytes, &msg)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	digest := msg.Cid().Bytes()
+
+	err = r.VerifyRaw(digest, pk, sig)
+
+	if err != nil {
+		t.Fail()
+	}
 }
 
 func TestConstructPayment(t *testing.T) {

--- a/construction_impl_test.go
+++ b/construction_impl_test.go
@@ -47,6 +47,41 @@ func seq() func() {
 	}
 }
 
+func verify(unsignedTx string, pkHex string, sigBase64 string) error {
+	pk, err := hex.DecodeString(pkHex)
+	if err != nil {
+		return err
+	}
+	sig, err := base64.StdEncoding.DecodeString(sigBase64)
+	if err != nil {
+		return err
+	}
+	r := NewRosettaConstructionFilecoin(NETWORK)
+
+	rawIn := json.RawMessage(unsignedTx)
+
+	bytes, err := rawIn.MarshalJSON()
+	if err != nil {
+		return err
+	}
+
+	var msg types.Message
+	err = json.Unmarshal(bytes, &msg)
+	if err != nil {
+		return err
+	}
+
+	digest := msg.Cid().Bytes()
+
+	err = r.VerifyRaw(digest, pk, sig)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func TestDeriveFromPublicKey(t *testing.T) {
 	pk, err := hex.DecodeString("04fc016f3d88dc7070cdd95b5754d32fd5290f850b7c2208fca0f715d35861de1841d9a342a487692a63810a6c906b443a18aa804d9d508d69facc5b06789a01b4")
 	if err != nil {
@@ -121,33 +156,11 @@ func TestVerify(t *testing.T) {
     "Params": ""
   }`
 
-	pk, err := hex.DecodeString("0435e752dc6b4113f78edcf2cf7b8082e442021de5f00818f555397a6f181af795ace98f0f7d065793eaffa1b06bf52e572c97030c53a2396dfab40ba0e976b108")
-	if err != nil {
-		t.Errorf(err.Error())
-	}
-	sig, err := base64.StdEncoding.DecodeString("nFuTI7MxEXqTQ0QmmQTmqbUsNZfHFXlNjz+susVDkAk1SrRCdJKxlVZZrM4vUtVBSYgtMIeigNfpqdKGIFhoWQA=")
-	if err != nil {
-		t.Errorf(err.Error())
-	}
-	r := NewRosettaConstructionFilecoin(NETWORK)
+	pkHex := "0435e752dc6b4113f78edcf2cf7b8082e442021de5f00818f555397a6f181af795ace98f0f7d065793eaffa1b06bf52e572c97030c53a2396dfab40ba0e976b108"
 
-	rawIn := json.RawMessage(unsignedTx)
+	sigBase64 := "nFuTI7MxEXqTQ0QmmQTmqbUsNZfHFXlNjz+susVDkAk1SrRCdJKxlVZZrM4vUtVBSYgtMIeigNfpqdKGIFhoWQA="
 
-	bytes, err := rawIn.MarshalJSON()
-	if err != nil {
-		t.Errorf(err.Error())
-	}
-
-	var msg types.Message
-	err = json.Unmarshal(bytes, &msg)
-	if err != nil {
-		t.Errorf(err.Error())
-	}
-
-	digest := msg.Cid().Bytes()
-
-	err = r.VerifyRaw(digest, pk, sig)
-
+	err := verify(unsignedTx, pkHex, sigBase64)
 	if err != nil {
 		t.Fail()
 	}
@@ -166,33 +179,10 @@ func TestVerify2(t *testing.T) {
 		"Params": ""
   }`
 
-	pk, err := hex.DecodeString("0435e752dc6b4113f78edcf2cf7b8082e442021de5f00818f555397a6f181af795ace98f0f7d065793eaffa1b06bf52e572c97030c53a2396dfab40ba0e976b108")
-	if err != nil {
-		t.Errorf(err.Error())
-	}
-	sig, err := base64.StdEncoding.DecodeString("0wRrFJZFIVh8m0JD+f5C55YrxD6YAWtCXWYihrPTKdMfgMhYAy86MVhs43hSLXnV+47UReRIe8qFdHRJqFlreAE=")
-	if err != nil {
-		t.Errorf(err.Error())
-	}
-	r := &RosettaConstructionFilecoin{false}
+	pkHex := "0435e752dc6b4113f78edcf2cf7b8082e442021de5f00818f555397a6f181af795ace98f0f7d065793eaffa1b06bf52e572c97030c53a2396dfab40ba0e976b108"
+	sigBase64 := "0wRrFJZFIVh8m0JD+f5C55YrxD6YAWtCXWYihrPTKdMfgMhYAy86MVhs43hSLXnV+47UReRIe8qFdHRJqFlreAE="
 
-	rawIn := json.RawMessage(unsignedTx)
-
-	bytes, err := rawIn.MarshalJSON()
-	if err != nil {
-		t.Errorf(err.Error())
-	}
-
-	var msg types.Message
-	err = json.Unmarshal(bytes, &msg)
-	if err != nil {
-		t.Errorf(err.Error())
-	}
-
-	digest := msg.Cid().Bytes()
-
-	err = r.VerifyRaw(digest, pk, sig)
-
+	err := verify(unsignedTx, pkHex, sigBase64)
 	if err != nil {
 		t.Fail()
 	}

--- a/construction_onchain_test.go
+++ b/construction_onchain_test.go
@@ -202,6 +202,7 @@ func TestSendTransaction(t *testing.T) {
 
 	// Send request
 	res, err := sendLotusRequest("Filecoin.MpoolPush", 1, signedTx)
+	fmt.Printf("%v\n", res)
 	assert.NoError(t, err)
 	assert.NotNil(t, res["result"])
 


### PR DESCRIPTION
Verify signatures of signed message before giving hash. This avoid silent error linked to badly formed JSON.

Closes #21 

<!-- ClickUpRef: 2p6bxz4 -->
:link: [zboto Link](https://app.clickup.com/t/2p6bxz4)