### PR TITLE
Support lotus v1.36.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/filecoin-project/go-address v1.2.0
 	github.com/filecoin-project/go-crypto v0.1.0
 	github.com/filecoin-project/go-state-types v0.18.0
-	github.com/filecoin-project/lotus v1.36.0-rc1
+	github.com/filecoin-project/lotus v1.36.0
 	github.com/filecoin-project/specs-actors v0.9.15
 	github.com/filecoin-project/specs-actors/v2 v2.3.6
 	github.com/filecoin-project/specs-actors/v3 v3.1.2

--- a/go.sum
+++ b/go.sum
@@ -174,8 +174,8 @@ github.com/filecoin-project/go-state-types v0.1.0/go.mod h1:ezYnPf0bNkTsDibL/psS
 github.com/filecoin-project/go-state-types v0.1.6/go.mod h1:UwGVoMsULoCK+bWjEdd/xLCvLAQFBC7EDT477SKml+Q=
 github.com/filecoin-project/go-state-types v0.18.0 h1:oDcjihXRlf2cM176atZzllp79Zc+kcbiuQM9DPL/1a4=
 github.com/filecoin-project/go-state-types v0.18.0/go.mod h1:CcyG4ZQRDWW+QUY2WDf1KtVDRN7W4twjsfgnGbQfJVI=
-github.com/filecoin-project/lotus v1.36.0-rc1 h1:1qOxGq3+9XTyNt51gKuCjfS5T59+mZzf1cyBNxCEevo=
-github.com/filecoin-project/lotus v1.36.0-rc1/go.mod h1:tzFOxSSszbfgocCRMsAraa9C3Jj3iEIEiOY9Pf9CsmY=
+github.com/filecoin-project/lotus v1.36.0 h1:Rw8SSZ7obavxC0sBm9EpAvXv+ggqNcDNNMmdV0my2Bs=
+github.com/filecoin-project/lotus v1.36.0/go.mod h1:tzFOxSSszbfgocCRMsAraa9C3Jj3iEIEiOY9Pf9CsmY=
 github.com/filecoin-project/specs-actors v0.9.13/go.mod h1:TS1AW/7LbG+615j4NsjMK1qlpAwaFsG9w0V2tg2gSao=
 github.com/filecoin-project/specs-actors v0.9.15-0.20220514164640-94e0d5e123bd/go.mod h1:pjGEe3QlWtK20ju/aFRsiArbMX6Cn8rqEhhsiCM9xYE=
 github.com/filecoin-project/specs-actors v0.9.15 h1:3VpKP5/KaDUHQKAMOg4s35g/syDaEBueKLws0vbsjMc=


### PR DESCRIPTION
## Summary

Bumps the Lotus dependency from `v1.36.0-rc1` to the stable `v1.36.0` release. First leg of the lib → proxy release cycle for the NV28 ("Fire Horse") network upgrade — mandatory mainnet epoch **6052800 / 2026-05-27T14:00:00Z**.

## What changed in the lib

Minimal — `go.mod` lotus line + matching `go.sum` hashes. Nothing else needed:

| Check | State |
|-------|-------|
| `go mod tidy` | No transitive churn (rc1 → stable is a no-op upstream) |
| `LatestVersion = network.Version28` (`actors/actors.go`) | Already correct; NV28 was set in PR #207 |
| `_ "github.com/filecoin-project/lotus/build"` blank import | Still in place at `actors/actors.go:20` |
| Go directive in lotus's `go.mod` | `1.25.7` — matches lib (no CI workflow bump needed) |
| `go build ./...` / `go vet ./...` | Clean |

## What changed upstream rc1 → stable (FYI)

Four commits in lotus, none touching the lib's API surface:

1. `c7e3b7e` (#13617) — eth filter cap behavior: single-tipset queries bypass `MaxFilterResults`. Doesn't affect lib (we don't issue eth filter queries).
2. `75d7758` (#13620) — `chain/sync.go` nil-guard on bls/secp message arrays. Internal safety.
3. `92ec445` (#13619) — Set `UpgradeFireHorseHeight = 6052800` for mainnet. Build constant only.
4. `154c0c3` — Version bump + CHANGELOG.

## CI gating

The `test` job exercises a live **devnet** Lotus RPC. The dev cluster was decommissioned; a new devnet pod is being stood up on the **pro** cluster at `https://node-fil-devnet.zondax.ch/rpc/v1` (project-filecoin#1138 / #1139 / #1140). Once that endpoint is healthy and the `LOTUS_URL_DEVNET` org secret is updated to point at the `.ch` hostname, the `test` job should pass against a real v1.36.0 binary — that's the actual validation for the rc1 → stable bump, not just `go build`.

Until the endpoint is up, the `test` job is expected to fail with the 503 / `panic: interface conversion: interface {} is nil, not map[string]interface {}` pattern (HTML-from-ingress can't be parsed as JSON-RPC).

## Supersedes

- `#209` — dependabot bumping lotus 1.36.0-rc1 → 1.36.0 (same change; closing in favor of this conventional `feat/lotus-1.36.0` branch). Will close once this PR is open.

`#208` (jsonparser 1.1.1 → 1.1.2) is independent and not included here.

## Follow-ups (after merge)

- Tag `v1.3600.0` and create a GH release (per the lockstep tag scheme: lotus `v1.36.0` → lib `v1.3600.0`).
- Open the `rosetta-filecoin-proxy` companion PR consuming this tag (separate skill: `fil-rosetta-proxy-upgrade`).